### PR TITLE
Fix missing uploaded log link on Paper/Folia 26.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ out
 .idea/*
 !.idea/scopes
 
+# vscode
+.vscode/*
+
 # gradle
 build
 .gradle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.3.1
+- Fix the uploaded log link not being displayed on Paper 26.2
+
+---
+
 # 3.3.0
 - Update to 26.2
 

--- a/bukkit/src/main/java/gs/mclo/commands/BukkitCommandSenderAccessor.java
+++ b/bukkit/src/main/java/gs/mclo/commands/BukkitCommandSenderAccessor.java
@@ -35,6 +35,10 @@ public class BukkitCommandSenderAccessor extends AdventureCommandSourceAccessor 
 
     @Override
     protected Audience getAudience() {
+        if (commandSender instanceof Audience audience) {
+            return audience;
+        }
+
         return plugin.audience(commandSender);
     }
 }


### PR DESCRIPTION
## Summary

Fixes the generated mclo.gs link not being displayed after running `/mclogs` on Paper/Folia 26.2.

Paper 26.2 now provides its command senders as native Adventure audiences. The Bukkit implementation now uses that native audience when available, while retaining the existing `BukkitAudiences` adapter as a fallback for other Bukkit-based platforms.

The changelog has also been prepared for version 3.3.1.

## Testing

Tested with Paper 26.2 build 87:

- The log was uploaded successfully.
- The generated mclo.gs URL appeared in the console.
- The delete action was displayed correctly.
- The Bukkit module builds successfully.

Fixes #10