### PR TITLE
🐛 Stop config file watcher on client shutdown

### DIFF
--- a/bukkit/src/main/java/gs/mclo/MclogsBukkitPlugin.java
+++ b/bukkit/src/main/java/gs/mclo/MclogsBukkitPlugin.java
@@ -33,6 +33,7 @@ public class MclogsBukkitPlugin extends JavaPlugin {
             adventure.close();
             adventure = null;
         }
+        mclogsCommon.shutdown();
     }
 
     private BukkitAudiences adventure() {

--- a/bungeecord/src/main/java/gs/mclo/MclogsBungeePlugin.java
+++ b/bungeecord/src/main/java/gs/mclo/MclogsBungeePlugin.java
@@ -33,6 +33,7 @@ public class MclogsBungeePlugin extends Plugin {
             adventure.close();
             adventure = null;
         }
+        mclogsCommon.shutdown();
     }
 
     private BungeeAudiences adventure() {

--- a/common/src/main/java/gs/mclo/MclogsCommon.java
+++ b/common/src/main/java/gs/mclo/MclogsCommon.java
@@ -1,6 +1,7 @@
 package gs.mclo;
 
 import com.electronwill.nightconfig.core.file.FileConfig;
+import com.electronwill.nightconfig.core.file.FileWatcher;
 import com.electronwill.nightconfig.core.serde.ObjectDeserializer;
 import com.electronwill.nightconfig.core.serde.ObjectSerializer;
 import com.mojang.brigadier.CommandDispatcher;
@@ -115,5 +116,9 @@ public class MclogsCommon {
 
     public Map<String, UploadLogResponse> getSharedLogs() {
         return sharedLogs;
+    }
+
+    public void shutdown() {
+        FileWatcher.defaultInstance().stop();
     }
 }

--- a/fabric/src/main/java/gs/mclo/FabricInitializer.java
+++ b/fabric/src/main/java/gs/mclo/FabricInitializer.java
@@ -1,10 +1,13 @@
 package gs.mclo;
 
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 
 public class FabricInitializer implements ModInitializer {
     @Override
     public void onInitialize() {
         MclogsFabric.INSTANCE.init();
+
+        ClientLifecycleEvents.CLIENT_STOPPING.register(_ -> MclogsFabric.INSTANCE.shutdown());
     }
 }

--- a/forge/src/main/java/gs/mclo/MclogsForge.java
+++ b/forge/src/main/java/gs/mclo/MclogsForge.java
@@ -2,6 +2,7 @@ package gs.mclo;
 
 import gs.mclo.commands.ClientCommandSourceStackBuildContext;
 import net.minecraftforge.client.event.RegisterClientCommandsEvent;
+import net.minecraftforge.event.GameShuttingDownEvent;
 import net.minecraftforge.event.RegisterCommandsEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -12,6 +13,7 @@ public class MclogsForge extends MclogsCommonMc {
         this.init();
         RegisterClientCommandsEvent.BUS.addListener(this::registerClientCommands);
         RegisterCommandsEvent.BUS.addListener(this::registerCommands);
+        GameShuttingDownEvent.BUS.addListener(this::onGameShuttingDown);
     }
 
     public void registerClientCommands(RegisterClientCommandsEvent event) {
@@ -20,5 +22,9 @@ public class MclogsForge extends MclogsCommonMc {
 
     public void registerCommands(RegisterCommandsEvent event) {
         registerCommandsOnDedicatedServer(event.getDispatcher());
+    }
+
+    public void onGameShuttingDown(GameShuttingDownEvent event) {
+        shutdown();
     }
 }

--- a/neoforge/src/main/java/gs/mclo/MclogsNeoForge.java
+++ b/neoforge/src/main/java/gs/mclo/MclogsNeoForge.java
@@ -7,6 +7,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.client.event.RegisterClientCommandsEvent;
 import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.GameShuttingDownEvent;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
 
 @Mod(Constants.MOD_ID)
@@ -25,5 +26,10 @@ public class MclogsNeoForge extends MclogsCommonMc {
     @SubscribeEvent
     public void registerCommands(RegisterCommandsEvent event) {
         registerCommandsOnDedicatedServer(event.getDispatcher());
+    }
+
+    @SubscribeEvent
+    private void onGameShuttingDown(GameShuttingDownEvent event) {
+        shutdown();
     }
 }

--- a/velocity/src/main/java/gs/mclo/MclogsVelocityPlugin.java
+++ b/velocity/src/main/java/gs/mclo/MclogsVelocityPlugin.java
@@ -6,6 +6,7 @@ import com.velocitypowered.api.command.BrigadierCommand;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
 import gs.mclo.commands.CommandEnvironment;
@@ -34,6 +35,11 @@ public class MclogsVelocityPlugin extends MclogsCommon {
         init();
 
         registerCommands();
+    }
+
+    @Subscribe
+    public void onProxyShutdown(ProxyShutdownEvent event) {
+        shutdown();
     }
 
     protected void registerCommands() {


### PR DESCRIPTION
NightConfig's default FileWatcher keeps a non-daemon executor thread alive after the Minecraft client has finished shutting down. This prevents the JVM from terminating normally and eventually triggers Minecraft's client shutdown watchdog.

Add a common shutdown hook that stops the default FileWatcher and invoke it in all stop lifecycle events.

This ensures the configuration watcher is terminated before the client exits and prevents the shutdown watchdog crash.